### PR TITLE
[admin] Fix performance issues by using raw_id_fields for the headquarter field

### DIFF
--- a/django_sirene/admin.py
+++ b/django_sirene/admin.py
@@ -3,28 +3,25 @@ from .models import Institution
 
 
 class InstitutionAdmin(admin.ModelAdmin):
-    search_fields = (
-        'siret',
-        "name",
-        "commercial_name"
-    )
+    search_fields = ("siret", "name", "commercial_name")
     list_select_related = (
-        'legal_status',
-        'headquarter',
-        'municipality',
-        'activity',
+        "legal_status",
+        "headquarter",
+        "municipality",
+        "activity",
     )
     list_display = (
-        'siret',
-        '__str__',
-        'zipcode',
-        'municipality',
-        'headquarter',
-        'is_headquarter',
-        'is_expired',
-        'updated',
-        'created',
+        "siret",
+        "__str__",
+        "zipcode",
+        "municipality",
+        "headquarter",
+        "is_headquarter",
+        "is_expired",
+        "updated",
+        "created",
     )
+    raw_id_fields = ("headquarter",)
 
 
 admin.site.register(Institution, InstitutionAdmin)

--- a/django_sirene/admin.py
+++ b/django_sirene/admin.py
@@ -21,7 +21,8 @@ class InstitutionAdmin(admin.ModelAdmin):
         "updated",
         "created",
     )
-    raw_id_fields = ("headquarter", "legal_status", "municipality", "activity")
+    exclude = ("headquarter",)
+    raw_id_fields = ("legal_status", "municipality", "activity")
 
 
 admin.site.register(Institution, InstitutionAdmin)

--- a/django_sirene/admin.py
+++ b/django_sirene/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Institution
+from .models import Activity, Institution, LegalStatus, Municipality
 
 
 class InstitutionAdmin(admin.ModelAdmin):
@@ -21,8 +21,33 @@ class InstitutionAdmin(admin.ModelAdmin):
         "updated",
         "created",
     )
-    exclude = ("headquarter",)
-    raw_id_fields = ("legal_status", "municipality", "activity")
+    autocomplete_fields = ("activity", "legal_status", "municipality")
+    raw_id_fields = ("headquarter",)
 
 
 admin.site.register(Institution, InstitutionAdmin)
+
+
+class DjangoSireneBaseAdmin:
+    search_fields = ("code", "name")
+
+
+class ActivityAdmin(DjangoSireneBaseAdmin, admin.ModelAdmin):
+    pass
+
+
+admin.site.register(Activity, ActivityAdmin)
+
+
+class LegalStatusAdmin(DjangoSireneBaseAdmin, admin.ModelAdmin):
+    pass
+
+
+admin.site.register(LegalStatus, LegalStatusAdmin)
+
+
+class MunicipalityAdmin(DjangoSireneBaseAdmin, admin.ModelAdmin):
+    pass
+
+
+admin.site.register(Municipality, MunicipalityAdmin)

--- a/django_sirene/admin.py
+++ b/django_sirene/admin.py
@@ -21,7 +21,7 @@ class InstitutionAdmin(admin.ModelAdmin):
         "updated",
         "created",
     )
-    raw_id_fields = ("headquarter",)
+    raw_id_fields = ("headquarter", "legal_status", "municipality", "activity")
 
 
 admin.site.register(Institution, InstitutionAdmin)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-sirene',
-    version='0.2',
+    version='3.0.3',
     packages=find_packages(),
     install_requires=[
         "django-bulk-update>=2.2.0",


### PR DESCRIPTION
We face some trouble accessing the edit view for django_sirene Institutions.
This is due to the fact that the headquarter field had to load all the institutions of our database.
By making this a raw id field should limit those performance issues.